### PR TITLE
CellBars — tester kit and WS bridge stub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,3 +76,18 @@ jobs:
           else
             echo "Gradle wrapper not found yet; skipping."
           fi
+
+  bridge-java-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Build & Test Bridge
+        run: |
+          if [ -f apps/proxy-java/gradlew ]; then
+            cd apps/proxy-java
+            ./gradlew test --no-daemon -q
+          fi

--- a/apps/addon/appsscript.json
+++ b/apps/addon/appsscript.json
@@ -1,0 +1,18 @@
+{
+  "timeZone": "America/Detroit",
+  "dependencies": {},
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets.currentonly",
+    "https://www.googleapis.com/auth/script.container.ui"
+  ],
+  "exceptionLogging": "STACKDRIVER",
+  "addOns": {
+    "common": {
+      "name": "DAWSheet",
+      "logoUrl": "https://raw.githubusercontent.com/2nist/dawsheet/main/assets/icon.png",
+      "layoutProperties": { "primaryColor": "#111827" },
+      "homepageTrigger": { "runFunction": "showWelcome", "enabled": true }
+    },
+    "sheets": {}
+  }
+}

--- a/apps/addon/src/Code.gs
+++ b/apps/addon/src/Code.gs
@@ -1,0 +1,13 @@
+function showWelcome() {
+  const html = HtmlService.createTemplateFromFile('welcome').evaluate()
+    .setTitle('DAWSheet')
+    .setSandboxMode(HtmlService.SandboxMode.IFRAME);
+  SpreadsheetApp.getUi().showSidebar(html);
+}
+
+function onOpen(){ showWelcome(); } // optional: always open on first use
+
+// Feature flag stub for Pro Mode
+function isProModeEnabled() {
+  return false; // v1: no Pub/Sub; bridge-only
+}

--- a/apps/addon/src/templates.gs
+++ b/apps/addon/src/templates.gs
@@ -1,0 +1,89 @@
+/**
+ * Inserts a Timeline with bar:beat headers and a simple transport strip.
+ */
+function insertTimeline() {
+  const ss = SpreadsheetApp.getActive();
+  const sh = ss.getActiveSheet();
+  const start = sh.getActiveRange() || sh.getRange(1,1);
+  const row = start.getRow();
+  const col = start.getColumn();
+  const bars = 8; // simple default
+  // Header row: Bar:Beat
+  const header = [];
+  for (let b = 1; b <= bars; b++) {
+    for (let beat = 1; beat <= 4; beat++) header.push(`${b}:${beat}`);
+  }
+  sh.getRange(row, col, 1, header.length).setValues([header]);
+  // Accent every 4th column via conditional formatting
+  const range = sh.getRange(row, col, 1, header.length);
+  const rules = sh.getConditionalFormatRules();
+  const rule = SpreadsheetApp.newConditionalFormatRule()
+    .whenFormulaSatisfied(`=MOD(COLUMN()-${col}+1,4)=1`)
+    .setBackground('#1f2937')
+    .setRanges([range])
+    .build();
+  rules.push(rule);
+  sh.setConditionalFormatRules(rules);
+}
+
+/**
+ * Inserts a 16-step drum grid with checkbox/velocity/probability rows.
+ */
+function insertStepGrid() {
+  const ss = SpreadsheetApp.getActive();
+  const sh = ss.getActiveSheet();
+  const start = sh.getActiveRange() || sh.getRange(1,1);
+  const row = start.getRow();
+  const col = start.getColumn();
+  // Labels
+  sh.getRange(row, col, 3, 1).setValues([["On"],["Vel"],["Prob"]]);
+  // Steps 1..16
+  const steps = Array.from({length:16}, (_,i)=> i+1);
+  sh.getRange(row, col+1, 1, 16).setValues([steps]);
+  // On: checkboxes
+  const onRange = sh.getRange(row, col+1, 1, 16);
+  onRange.insertCheckboxes();
+  // Vel row defaults 100
+  sh.getRange(row+1, col+1, 1, 16).setValues([Array(16).fill(100)]);
+  // Prob row defaults 1.0
+  sh.getRange(row+2, col+1, 1, 16).setValues([Array(16).fill(1.0)]);
+  // Named range convention (for compiler to detect)
+  ss.setNamedRange('CTRL_STEP16_BLOCK', sh.getRange(row, col, 3, 17));
+}
+
+/**
+ * onEdit compiler: watches template blocks and appends envelopes to Emit!A:A
+ */
+function onEdit(e) {
+  try {
+    if (!e) return;
+    const ss = SpreadsheetApp.getActive();
+    const block = ss.getRangeByName('CTRL_STEP16_BLOCK');
+    if (block && e.range && block.getA1Notation() && block.getSheet().getName() === e.range.getSheet().getName()) {
+      const r = e.range;
+      // If an On cell was toggled, emit NOTE.PLAY
+      if (r.getRow() === block.getRow() && r.getColumn() > block.getColumn()) {
+        const stepIdx = r.getColumn() - block.getColumn();
+        const vel = block.getCell(2, stepIdx+1).getValue() || 100;
+        const on = r.getValue() === true;
+        if (on) {
+          const env = {
+            v:1, type:'NOTE.PLAY', id: `step_${Date.now()}`, origin: `sheets://${r.getSheet().getName()}!${r.getA1Notation()}`,
+            at:'now', target:'default',
+            payload: { note: 60, velocity: vel, durationSec: 0.25, channel: 1 }
+          };
+          appendEmitRow(JSON.stringify(env));
+        }
+      }
+    }
+  } catch (err) {
+    // swallow
+  }
+}
+
+function appendEmitRow(json) {
+  const ss = SpreadsheetApp.getActive();
+  let sh = ss.getSheetByName('Emit');
+  if (!sh) sh = ss.insertSheet('Emit');
+  sh.appendRow([json]);
+}

--- a/apps/addon/src/welcome.html
+++ b/apps/addon/src/welcome.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DAWSheet</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, sans-serif; margin: 0; background:#0f172a; color:#e5e7eb; }
+    header { padding: 12px 16px; border-bottom: 1px solid #1f2937; display:flex; align-items:center; gap:8px; }
+    header img { width:20px; height:20px; }
+    h1 { font-size: 16px; margin: 0; font-weight:600; }
+    main { padding: 16px; display:flex; flex-direction:column; gap:12px; }
+    section { background:#111827; border:1px solid #1f2937; border-radius:8px; padding:12px; }
+    .row { display:flex; gap:8px; flex-wrap:wrap; align-items:center; }
+    button { background:#10b981; border:none; color:#0b141d; padding:8px 12px; border-radius:6px; font-weight:600; cursor:pointer; }
+    button.secondary { background:#374151; color:#e5e7eb; }
+    small { color:#9ca3af; }
+    select, input[type="text"] { background:#0b1220; color:#e5e7eb; border:1px solid #1f2937; border-radius:6px; padding:6px 8px; }
+    a { color:#60a5fa; text-decoration:none; }
+  </style>
+</head>
+<body>
+  <header>
+    <img src="https://raw.githubusercontent.com/2nist/dawsheet/main/assets/icon.png" alt="icon" />
+    <h1>DAWSheet</h1>
+  </header>
+  <main>
+    <section>
+      <div class="row">
+        <button id="playKick">Play Test Kick</button>
+        <small>Web Audio: instant sound</small>
+      </div>
+    </section>
+    <section>
+      <div class="row" style="gap:12px; align-items:center;">
+        <button id="enableMidi">Enable MIDI</button>
+        <label>Output: <select id="midiOut"></select></label>
+        <button id="sendMidi" class="secondary">Send Test Note</button>
+      </div>
+      <small id="midiStatus">Web MIDI is optional; use loopMIDI/IAC to reach your DAW.</small>
+    </section>
+    <section>
+      <div class="row">
+        <button id="insertTimeline" class="secondary">Insert Timeline</button>
+        <button id="insertStep" class="secondary">Insert 16-Step Drum Grid</button>
+      </div>
+      <small>Template Mode writes envelopes to Emit!A:A.</small>
+    </section>
+    <section>
+      <div class="row">
+        <a href="https://github.com/2nist/dawsheet/releases" target="_blank">Advanced: Use Desktop Bridge</a>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    // Web Audio - Kick & Hat
+    function playKick() {
+      const ac = new (window.AudioContext || window.webkitAudioContext)();
+      const t0 = ac.currentTime + 0.02;
+      const kick = ac.createOscillator();
+      const gain = ac.createGain();
+      kick.type = 'sine';
+      kick.frequency.setValueAtTime(120, t0);
+      kick.frequency.exponentialRampToValueAtTime(40, t0 + 0.12);
+      gain.gain.setValueAtTime(1.0, t0);
+      gain.gain.exponentialRampToValueAtTime(0.001, t0 + 0.15);
+      kick.connect(gain).connect(ac.destination);
+      kick.start(t0); kick.stop(t0 + 0.16);
+      // light hat
+      const hat = ac.createOscillator();
+      const hatGain = ac.createGain();
+      hat.type = 'triangle';
+      hat.frequency.setValueAtTime(8000, t0 + 0.1);
+      hatGain.gain.setValueAtTime(0.15, t0 + 0.1);
+      hatGain.gain.exponentialRampToValueAtTime(0.0001, t0 + 0.18);
+      hat.connect(hatGain).connect(ac.destination);
+      hat.start(t0 + 0.1); hat.stop(t0 + 0.2);
+    }
+
+    document.getElementById('playKick').addEventListener('click', playKick);
+
+    // Web MIDI
+    let midi = null; let outputs = [];
+    async function enableMIDI() {
+      try {
+        const access = await navigator.requestMIDIAccess({ sysex: false });
+        midi = access;
+        outputs = Array.from(access.outputs.values());
+        const sel = document.getElementById('midiOut');
+        sel.innerHTML = '';
+        outputs.forEach((o, i) => {
+          const opt = document.createElement('option');
+          opt.value = i; opt.textContent = o.name;
+          sel.appendChild(opt);
+        });
+        document.getElementById('midiStatus').textContent = outputs.length ? 'MIDI enabled' : 'No outputs. Try loopMIDI/IAC.';
+      } catch (e) {
+        document.getElementById('midiStatus').textContent = 'Web MIDI unavailable in this browser.';
+      }
+    }
+    document.getElementById('enableMidi').addEventListener('click', enableMIDI);
+
+    function sendTestNote() {
+      if (!outputs.length) return;
+      const sel = document.getElementById('midiOut');
+      const out = outputs[sel.selectedIndex || 0];
+      const ch = 0; const note = 60; const vel = 100;
+      out.send([0x90 + ch, note, vel]);
+      setTimeout(() => out.send([0x80 + ch, note, 0]), 250);
+    }
+    document.getElementById('sendMidi').addEventListener('click', sendTestNote);
+
+    // Template hooks (server-side to implement): insertTimeline, insertStepGrid
+    document.getElementById('insertTimeline').addEventListener('click', () => google.script.run.insertTimeline());
+    document.getElementById('insertStep').addEventListener('click', () => google.script.run.insertStepGrid());
+  </script>
+</body>
+</html>

--- a/apps/proxy-java/README.md
+++ b/apps/proxy-java/README.md
@@ -1,0 +1,45 @@
+DAWSheet Java Proxy
+===================
+
+Listens to Google Cloud Pub/Sub for DAWSheet commands and plays MIDI in real time.
+
+Requirements
+
+- Java 17+
+- Google Cloud credentials with Pub/Sub Subscriber (via `gcloud auth application-default login` or `GOOGLE_APPLICATION_CREDENTIALS`)
+
+Environment
+
+- `GCP_PROJECT_ID` (required)
+- `COMMANDS_SUB` (required) Pub/Sub subscription ID bound to `dawsheet.commands`
+- `STATUS_TOPIC` (optional) topic name (e.g., `dawsheet.status`) to publish ACK messages
+- `MIDI_OUT` (optional) partial device name; if not provided, uses Java Synthesizer
+- `PROXY_ID` (optional) defaults to `java-proxy`
+
+Usage
+
+```powershell
+# In apps/proxy-java
+gradlew.bat runWithEnv
+```
+
+Edit `.env` or export environment variables (the `runWithEnv` task will load `.env`).
+
+Example `.env`:
+
+```ini
+GCP_PROJECT_ID=your-project
+COMMANDS_SUB=dawsheet.commands-sub
+STATUS_TOPIC=dawsheet.status
+MIDI_OUT=Microsoft GS Wavetable Synth
+PROXY_ID=laptop-proxy
+```
+
+Create a subscription if you don't have one yet:
+
+```powershell
+& "..\..\..\google-cloud-sdk\bin\gcloud.cmd" config set project your-project
+& "..\..\..\google-cloud-sdk\bin\gcloud.cmd" pubsub subscriptions create dawsheet.commands-sub --topic dawsheet.commands
+```
+
+Then type `C4, vel=100, dur=0.5` in your Sheet. You should hear a note.

--- a/apps/proxy-java/build.gradle
+++ b/apps/proxy-java/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     // JSON parsing
     implementation 'com.google.code.gson:gson:2.10.1'
 
+
     // JUnit Jupiter for testing (Gradle 9 compatible)
     testImplementation 'org.junit.jupiter:junit-jupiter:5.10.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
@@ -49,6 +50,9 @@ application {
 test {
     useJUnitPlatform()
 }
+
+// Make the root spec available on the classpath at runtime (copy into resources)
+
 
 // Custom task to run the application and load environment variables from a .env file
 task runWithEnv(type: JavaExec) {

--- a/apps/proxy-java/src/main/java/io/dawsheet/App.java
+++ b/apps/proxy-java/src/main/java/io/dawsheet/App.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.dawsheet.midi.MidiOut;
 import io.dawsheet.midi.NoteUtil;
+import io.dawsheet.schema.SchemaValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,7 +53,14 @@ public class App {
                 String data = message.getData().toStringUtf8();
                 try {
                     JsonObject root = gson.fromJson(data, JsonObject.class);
-                    if (root == null || !root.has("type")) {
+                    if (root == null) {
+                        throw new IllegalArgumentException("Invalid JSON");
+                    }
+                    // If envelope version is present, validate against schema first
+                    if (root.has("v")) {
+                        SchemaValidator.validate(data);
+                    }
+                    if (!root.has("type")) {
                         throw new IllegalArgumentException("Missing 'type' field");
                     }
                     String type = root.get("type").getAsString();

--- a/apps/proxy-java/src/main/java/io/dawsheet/schema/SchemaValidator.java
+++ b/apps/proxy-java/src/main/java/io/dawsheet/schema/SchemaValidator.java
@@ -1,0 +1,88 @@
+package io.dawsheet.schema;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.util.regex.Pattern;
+
+/**
+ * Lightweight validator for DAWSheet command envelopes using Gson.
+ * Notes:
+ * - This is a pragmatic subset of the full JSON Schema validation, focused on core required fields and NOTE.PLAY.
+ * - It throws IllegalArgumentException on validation failures.
+ */
+public final class SchemaValidator {
+    private static final Pattern AT_BAR_BEAT = Pattern.compile("^\\d+:\\d+(?::\\d+)?$");
+    private static final Pattern AT_ISO = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.*$");
+
+    private SchemaValidator() {}
+
+    public static void validate(String json) {
+        JsonObject obj;
+        try {
+            obj = JsonParser.parseString(json).getAsJsonObject();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid JSON: " + e.getMessage(), e);
+        }
+        // Required top-level fields
+        int v = getInt(obj, "v", Integer.MIN_VALUE);
+        if (v != 1) throw new IllegalArgumentException("'v' must be 1");
+        String type = getString(obj, "type");
+        if (type.isEmpty()) throw new IllegalArgumentException("'type' is required");
+        String id = getString(obj, "id");
+        if (id.isEmpty()) throw new IllegalArgumentException("'id' is required");
+        String origin = getString(obj, "origin");
+        if (origin.isEmpty()) throw new IllegalArgumentException("'origin' is required");
+        String at = getString(obj, "at");
+        if (at.isEmpty()) throw new IllegalArgumentException("'at' is required");
+        if (!("now".equals(at) || AT_BAR_BEAT.matcher(at).matches() || AT_ISO.matcher(at).matches())) {
+            throw new IllegalArgumentException("'at' must be 'now', bar:beat[:ticks], or ISO-8601 datetime");
+        }
+        String target = getString(obj, "target");
+        if (target.isEmpty()) throw new IllegalArgumentException("'target' is required");
+        JsonObject payload = getObject(obj, "payload");
+
+        // Type-specific payload checks (NOTE.PLAY)
+        if ("NOTE.PLAY".equals(type)) {
+            validateNotePlayPayload(payload);
+        }
+        // Future: add more type-specific validations as needed.
+    }
+
+    private static void validateNotePlayPayload(JsonObject p) {
+        // note: string or integer 0..127
+        JsonElement noteEl = p.get("note");
+        if (noteEl == null) throw new IllegalArgumentException("payload.note is required");
+        if (noteEl.isJsonPrimitive() && noteEl.getAsJsonPrimitive().isNumber()) {
+            int n = noteEl.getAsInt();
+            if (n < 0 || n > 127) throw new IllegalArgumentException("payload.note int must be 0..127");
+        } else if (!(noteEl.isJsonPrimitive() && noteEl.getAsJsonPrimitive().isString())) {
+            throw new IllegalArgumentException("payload.note must be string or integer");
+        }
+        int velocity = getInt(p, "velocity", -1);
+        if (velocity < 1 || velocity > 127) throw new IllegalArgumentException("payload.velocity must be 1..127");
+        double durationSec = getDouble(p, "durationSec", -1);
+        if (durationSec < 0) throw new IllegalArgumentException("payload.durationSec must be >= 0");
+        int channel = getInt(p, "channel", -1);
+        if (channel < 1 || channel > 16) throw new IllegalArgumentException("payload.channel must be 1..16");
+    }
+
+    private static String getString(JsonObject o, String key) {
+        JsonElement e = o.get(key);
+        return (e != null && e.isJsonPrimitive() && e.getAsJsonPrimitive().isString()) ? e.getAsString() : "";
+    }
+    private static int getInt(JsonObject o, String key, int def) {
+        JsonElement e = o.get(key);
+        return (e != null && e.isJsonPrimitive() && e.getAsJsonPrimitive().isNumber()) ? e.getAsInt() : def;
+    }
+    private static double getDouble(JsonObject o, String key, double def) {
+        JsonElement e = o.get(key);
+        return (e != null && e.isJsonPrimitive() && e.getAsJsonPrimitive().isNumber()) ? e.getAsDouble() : def;
+    }
+    private static JsonObject getObject(JsonObject o, String key) {
+        JsonElement e = o.get(key);
+        if (e == null || !e.isJsonObject()) throw new IllegalArgumentException("'" + key + "' must be an object");
+        return e.getAsJsonObject();
+    }
+}

--- a/apps/proxy-java/src/test/java/io/dawsheet/schema/SchemaValidatorTest.java
+++ b/apps/proxy-java/src/test/java/io/dawsheet/schema/SchemaValidatorTest.java
@@ -1,0 +1,30 @@
+package io.dawsheet.schema;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class SchemaValidatorTest {
+
+    @Test
+    void validNotePlayEnvelope_passesValidation() {
+        String json = "{" +
+                "\"v\":1,\"type\":\"NOTE.PLAY\",\"id\":\"cmd_001\",\"origin\":\"sheets://Grid!A5\"," +
+                "\"at\":\"now\",\"target\":\"default\",\"payload\":{\"note\":\"C4\",\"velocity\":100,\"durationSec\":0.5,\"channel\":1}" +
+                "}";
+        assertDoesNotThrow(() -> SchemaValidator.validate(json));
+    }
+
+    @Test
+    void invalidEnvelope_missingRequiredField_failsValidation() {
+        // Missing 'id'
+        String json = "{" +
+                "\"v\":1,\"type\":\"NOTE.PLAY\",\"origin\":\"sheets://Grid!A5\",\"at\":\"now\",\"target\":\"default\"," +
+                "\"payload\":{\"note\":60,\"velocity\":100,\"durationSec\":0.2,\"channel\":1}" +
+                "}";
+    IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> SchemaValidator.validate(json));
+    // The exact message may vary, but it should complain about 'id'
+    assert(ex.getMessage().toLowerCase().contains("id"));
+    }
+}

--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,29 @@
+# DAWSheet Bridge (stub)
+
+Local WebSocket server for low-latency envelope playback.
+
+- **Endpoint:** `ws://127.0.0.1:17653`
+- **Implements:** `NOTE.PLAY` to default Java synth (more outputs later)
+- **Scheduling:** naive `now + 100ms` lookahead (tweak in code)
+- **Build:** Java 17 + Gradle
+
+## Build & Run
+
+```bash
+cd bridge
+./gradlew run           # macOS/Linux
+# or
+gradlew.bat run         # Windows
+```
+
+You should see: BridgeServer started on ws://127.0.0.1:17653
+
+## Test
+
+Open the Google Sheet with the add-on sidebar → Bridge → Connect → Bridge Test NOTE.PLAY. You should hear a beep from the Java synth.
+
+## Next
+
+- Output to selected MIDI port (Java Sound or rtmidi/JNA), not just default synth
+- Envelope types: PROGRAM.CHANGE, CC.SET, CHORD.PLAY, etc.
+- Real arrangement compiler → SMF export

--- a/distrib/cellbars_tester_kit/README.md
+++ b/distrib/cellbars_tester_kit/README.md
@@ -1,0 +1,3 @@
+# CellBars tester kit
+
+Import the `apps/addon/` files into a new Google Sheet's Apps Script project. Open the sidebar (menu: **DAWSheet — CellBars → Open**). See repo root for the Bridge stub.

--- a/distrib/cellbars_tester_kit/apps/addon/appsscript.json
+++ b/distrib/cellbars_tester_kit/apps/addon/appsscript.json
@@ -1,0 +1,18 @@
+{
+  "timeZone": "America/Detroit",
+  "dependencies": {},
+  "exceptionLogging": "STACKDRIVER",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets.currentonly",
+    "https://www.googleapis.com/auth/script.container.ui"
+  ],
+  "addOns": {
+    "common": {
+      "name": "DAWSheet — CellBars",
+      "logoUrl": "https://placehold.co/128x128?text=DAW",
+      "layoutProperties": { "primaryColor": "#111827" },
+      "homepageTrigger": { "runFunction": "showWelcome", "enabled": true }
+    },
+    "sheets": {}
+  }
+}

--- a/distrib/cellbars_tester_kit/apps/addon/src/Code.gs
+++ b/distrib/cellbars_tester_kit/apps/addon/src/Code.gs
@@ -1,0 +1,118 @@
+// DAWSheet — CellBars: Welcome + Init + Demo JSON + Bridge hooks (placeholder logo)
+
+const TAB_CONTROLS = 'Controls';
+const TAB_UI = 'UI';
+const TAB_EMIT = 'Emit';
+const TAB_TIMELINE = 'Timeline';
+const TAB_DEMO = 'WelcomeDemo';
+const DEMO_RANGE = 'A1';
+
+function onOpen() {
+  SpreadsheetApp.getUi()
+    .createMenu('DAWSheet — CellBars')
+    .addItem('Open', 'showWelcome')
+    .addItem('Initialize Workbook', 'initializeWorkbook')
+    .addToUi();
+}
+
+function showWelcome() {
+  const html = HtmlService.createTemplateFromFile('welcome').evaluate()
+    .setTitle('DAWSheet — CellBars')
+    .setSandboxMode(HtmlService.SandboxMode.IFRAME);
+  SpreadsheetApp.getUi().showSidebar(html);
+}
+
+function initializeWorkbook() {
+  const ss = SpreadsheetApp.getActive();
+  ensureSheet_(TAB_CONTROLS);
+  ensureSheet_(TAB_UI);
+  ensureSheet_(TAB_EMIT);
+  ensureSheet_(TAB_TIMELINE);
+  ensureSheet_(TAB_DEMO);
+  seedDemoSequenceIfMissing_();
+  const shC = ss.getSheetByName(TAB_CONTROLS);
+  if (shC.getLastRow() === 0) {
+    shC.getRange(1,1,1,8).setValues([[
+      'ControlID','Kind','CommandType','Target','Params','Defaults','UIStyle','Enabled'
+    ]]).setFontWeight('bold');
+  }
+  const shT = ss.getSheetByName(TAB_TIMELINE);
+  if (shT.getLastRow() === 0) {
+    shT.getRange(1,1,1,6).setValues([[
+      'Bar','Section','Track 1','Track 2','Track 3','Notes'
+    ]]).setFontWeight('bold');
+    shT.setFrozenRows(1); shT.setFrozenColumns(1);
+  }
+  SpreadsheetApp.getUi().alert('CellBars: Workbook initialized. Open the Welcome sidebar to continue.');
+}
+
+function ensureSheet_(name) {
+  const ss = SpreadsheetApp.getActive();
+  let sh = ss.getSheetByName(name);
+  if (!sh) sh = ss.insertSheet(name);
+  return sh;
+}
+
+function seedDemoSequenceIfMissing_(){
+  const sh = ensureSheet_(TAB_DEMO);
+  const cell = sh.getRange(DEMO_RANGE);
+  if (!cell.getValue()) {
+    const demo = {
+      "bpm":110,
+      "notes":[
+        {"t":0.00,"n":36,"v":110,"d":0.12,"ch":9},
+        {"t":0.25,"n":42,"v":80,"d":0.06,"ch":9},
+        {"t":0.50,"n":38,"v":105,"d":0.12,"ch":9},
+        {"t":0.75,"n":42,"v":80,"d":0.06,"ch":9},
+        {"t":1.00,"n":36,"v":115,"d":0.12,"ch":9},
+        {"t":1.25,"n":42,"v":80,"d":0.06,"ch":9},
+        {"t":1.50,"n":38,"v":105,"d":0.12,"ch":9},
+        {"t":1.75,"n":46,"v":85,"d":0.06,"ch":9}
+      ],
+      "loopSec":2.0
+    };
+    cell.setValue(JSON.stringify(demo, null, 2));
+    sh.getRange("A2").setValue("Edit JSON above to change the welcome demo sequence (bpm, notes[t,n,v,d,ch], loopSec).");
+  }
+}
+
+function getDemoSequenceJSON(){
+  seedDemoSequenceIfMissing_();
+  return SpreadsheetApp.getActive().getSheetByName(TAB_DEMO).getRange(DEMO_RANGE).getValue();
+}
+
+function saveDemoSequenceJSON(jsonStr){
+  try{ JSON.parse(jsonStr); }catch(e){ throw new Error('Invalid JSON: ' + e); }
+  SpreadsheetApp.getActive().getSheetByName(TAB_DEMO).getRange(DEMO_RANGE).setValue(jsonStr);
+  return true;
+}
+
+// --- Compiler stub (returns a tiny envelope list for Bridge) ---
+function getTestEnvelopes(){
+  return JSON.stringify([{
+    "v":1,"type":"NOTE.PLAY","id":"hello_"+Date.now(),
+    "at":"now","target":"default",
+    "payload":{"note":"C4","velocity":100,"durationSec":0.2,"channel":1}
+  }]);
+}
+
+function insertTimeline(){
+  const sh = SpreadsheetApp.getActive().getSheetByName(TAB_TIMELINE) || ensureSheet_(TAB_TIMELINE);
+  const startRow = Math.max(2, sh.getLastRow()+1);
+  for (let i=0;i<8;i++) sh.getRange(startRow+i, 1, 1, 2).setValues([[i+1, (i<4?'A':'B')]]);
+  const cols = sh.getMaxColumns();
+  for (let c=3;c<=cols;c++) if (((c-3) % 4) === 0) sh.getRange(1, c, sh.getMaxRows()).setBackground('#eef2ff');
+}
+
+function insertStepGrid16(){
+  const sh = SpreadsheetApp.getActive().getSheetByName(TAB_UI) || ensureSheet_(TAB_UI);
+  const start = sh.getActiveCell() || sh.getRange(2,2);
+  const rows = 3, cols = 16;
+  const block = sh.getRange(start.getRow(), start.getColumn(), rows, cols);
+  block.setBackground('#f5f7fa').setBorder(true, true, true, true, true, true);
+  sh.getRange(block.getRow(), block.getColumn(), 1, cols).insertCheckboxes();
+  sh.getRange(block.getRow()+1, block.getColumn(), 1, cols).setValues([Array(cols).fill(100)]).setNumberFormat('0');
+  sh.getRange(block.getRow()+2, block.getColumn(), 1, cols).setValues([Array(cols).fill(1)]).setNumberFormat('0.00');
+  SpreadsheetApp.getActive().setNamedRange('CTRL_STEPGRID16_BLOCK', block);
+  SpreadsheetApp.getUi().alert('Inserted Step Grid 16 at ' + block.getA1Notation());
+}

--- a/distrib/cellbars_tester_kit/apps/addon/src/welcome.html
+++ b/distrib/cellbars_tester_kit/apps/addon/src/welcome.html
@@ -1,0 +1,81 @@
+<!doctype html><html><head><meta charset="utf-8"><style>
+body{font:14px system-ui,-apple-system,Segoe UI,Roboto,sans-serif;color:#0f172a;margin:0}
+header{background:#0b1220;color:white;padding:14px 16px;font-weight:700}
+section{padding:12px 16px;border-bottom:1px solid #e5e7eb}
+h3{margin:0 0 8px 0;font-size:16px}
+button{padding:8px 12px;border:0;border-radius:8px;background:#111827;color:white;cursor:pointer}
+button.secondary{background:#4b5563}
+.row{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+textarea{width:100%;height:140px;font-family:ui-monospace,Menlo,Consolas,monospace;border-radius:8px;border:1px solid #cbd5e1;padding:8px}
+.tiny{font-size:12px;color:#6b7280;margin-top:6px}
+.ok{color:#065f46}.err{color:#7f1d1d}.pill{display:inline-block;padding:2px 8px;border-radius:12px;background:#e5e7eb;margin-left:6px;font-size:12px}
+.grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
+@media (max-width:720px){ .grid{grid-template-columns:1fr} }
+</style></head><body>
+<header>DAWSheet — CellBars</header>
+
+<section><h3>First sound</h3><div class="row">
+<button id="btnKick">Play Kick</button><button id="btnHat" class="secondary">Play Hat</button>
+<span id="latency" class="pill">Web Audio ready</span></div>
+<div class="tiny">Instant demo via Web Audio. For Logic, enable Web MIDI below and route to the IAC Driver.</div></section>
+
+<section><h3>Enable MIDI (for Logic)</h3><div class="row">
+<button id="btnMIDI">Enable MIDI</button><select id="midiOut" style="min-width:220px"></select>
+<button id="btnMIDITest" class="secondary">Send Test Note</button></div>
+<div id="midiMsg" class="tiny"></div></section>
+
+<section><h3>Bridge (Desktop) — optional</h3><div class="row">
+<button id="btnBridge">Connect to Bridge</button>
+<button id="btnBridgePing" class="secondary">Ping</button>
+<button id="btnBridgeNote" class="secondary">Bridge Test NOTE.PLAY</button>
+<span id="bridgeState" class="pill">Disconnected</span></div>
+<div class="tiny">Bridge expects <code>ws://127.0.0.1:17653</code>. Run the Java bridge in <code>bridge/</code>.</div></section>
+
+<section><h3>Welcome demo sequence</h3><div class="row">
+<button id="btnLoad" class="secondary">Load from Sheet</button><button id="btnSave">Save to Sheet</button>
+<button id="btnPlayDemo" class="secondary">Play Demo</button>
+<span class="tiny">{"bpm":120,"notes":[{"t":0,"n":36,"v":110,"d":0.12,"ch":9}]</span></div>
+<textarea id="jsonBox"></textarea><div id="saveMsg" class="tiny"></div></section>
+
+<section class="grid"><div><h3>Insert Timeline</h3><div class="row"><button id="btnTimeline">Insert</button></div>
+<div class="tiny">Rows = bars/sections. Use for arrangement, not jamming.</div></div>
+<div><h3>Insert 16-Step Grid</h3><div class="row"><button id="btnGrid">Insert</button></div>
+<div class="tiny">3×16 block (checkbox, velocity, probability) on the UI tab.</div></div></section>
+
+<script>
+const AC = window.AudioContext || window.webkitAudioContext; const ctx = new AC();
+function playKick(when = ctx.currentTime + 0.02){ const o = ctx.createOscillator(), g = ctx.createGain(); o.type='sine'; o.frequency.setValueAtTime(150, when); o.frequency.exponentialRampToValueAtTime(50, when + 0.12); g.gain.setValueAtTime(0.9, when); g.gain.exponentialRampToValueAtTime(0.0001, when + 0.12); o.connect(g).connect(ctx.destination); o.start(when); o.stop(when+0.13); }
+function playHat(when = ctx.currentTime + 0.02){ const b=ctx.createBuffer(1,22050,ctx.sampleRate); const d=b.getChannelData(0); for (let i=0;i<d.length;i++) d[i]=Math.random()*2-1; const s=ctx.createBufferSource(); s.buffer=b; const hp=ctx.createBiquadFilter(); hp.type='highpass'; hp.frequency.value=8000; const g=ctx.createGain(); g.gain.setValueAtTime(0.35, when); g.gain.exponentialRampToValueAtTime(0.0001, when+0.06); s.connect(hp).connect(g).connect(ctx.destination); s.start(when); s.stop(when+0.07); }
+function playSnare(when = ctx.currentTime + 0.02){ const b=ctx.createBuffer(1,22050,ctx.sampleRate); const d=b.getChannelData(0); for (let i=0;i<d.length;i++) d[i]=Math.random()*2-1; const s=ctx.createBufferSource(); s.buffer=b; const bp=ctx.createBiquadFilter(); bp.type='bandpass'; bp.frequency.value=1800; bp.Q=0.7; const g=ctx.createGain(); g.gain.setValueAtTime(0.5, when); g.gain.exponentialRampToValueAtTime(0.0001, when+0.12); s.connect(bp).connect(g).connect(ctx.destination); s.start(when); s.stop(when+0.13); }
+function playMIDIDrum(note, when){ if (note===36) return playKick(when); if (note===38) return playSnare(when); if (note===42||note===46) return playHat(when); }
+
+let midiOut=null; async function enableMIDI(){ const el=document.getElementById('midiMsg'); try{ if(!navigator.requestMIDIAccess){ el.textContent='Use Chrome for Web MIDI.'; return; } const access=await navigator.requestMIDIAccess({sysex:false}); const outs=Array.from(access.outputs.values()); const sel=document.getElementById('midiOut'); sel.innerHTML=''; outs.forEach(o=>{ const opt=document.createElement('option'); opt.value=o.id; opt.textContent=o.name; sel.appendChild(opt); }); if (outs.length){ midiOut=outs[0]; sel.value=midiOut.id; sel.onchange=()=>{ midiOut=outs.find(o=>o.id===sel.value); }; el.textContent='MIDI enabled.'; } else { el.textContent='No MIDI outputs found (enable IAC Driver).'; } }catch(e){ el.textContent='MIDI error: '+e; } }
+function sendMIDINoteOn(note=36, vel=110, ch=9){ if (!midiOut) return; midiOut.send([0x90|(ch&0x0F), note&0x7F, Math.max(0,Math.min(127,vel))]); }
+function sendMIDINoteOff(note=36, ch=9){ if (!midiOut) return; midiOut.send([0x80|(ch&0x0F), note&0x7F, 0]); }
+
+function loadFromSheet(){ google.script.run.withSuccessHandler(txt=>{ document.getElementById('jsonBox').value=txt; document.getElementById('saveMsg').textContent='Loaded.'; }).getDemoSequenceJSON(); }
+function saveToSheet(){ const txt=document.getElementById('jsonBox').value; google.script.run.withSuccessHandler(()=>{ document.getElementById('saveMsg').textContent='Saved.'; }).withFailureHandler(e=>{ document.getElementById('saveMsg').innerHTML='<span class=err>'+e+'</span>'; }).saveDemoSequenceJSON(txt); }
+function playDemo(){ let obj; try{ obj=JSON.parse(document.getElementById('jsonBox').value||'{}'); } catch{ document.getElementById('saveMsg').innerHTML='<span class=err>Invalid JSON</span>'; return; } const notes=Array.isArray(obj.notes)?obj.notes:[]; const start=ctx.currentTime+0.05; notes.forEach(ev=>{ const when=start+(Number(ev.t)||0); const n=Number(ev.n)||36; const v=Number(ev.v)||100; playMIDIDrum(n,when); if(midiOut){ sendMIDINoteOn(n,v,ev.ch||9); setTimeout(()=>sendMIDINoteOff(n,ev.ch||9),(ev.d||0.1)*1000); } }); }
+
+// Bridge WebSocket
+let ws=null;
+function connectBridge(){ try{ ws=new WebSocket('ws://127.0.0.1:17653'); ws.onopen=()=>{ setBridge('Connected'); ws.send(JSON.stringify({type:'HELLO',client:'dawsheet-addon'})); }; ws.onmessage=(ev)=>{}; ws.onclose=()=>setBridge('Disconnected'); ws.onerror=()=>setBridge('Error'); }catch(e){ setBridge('Error'); } }
+function setBridge(s){ document.getElementById('bridgeState').textContent=s; }
+function pingBridge(){ if(ws&&ws.readyState===1){ ws.send(JSON.stringify({type:'PING',ts:Date.now()})); } }
+function testBridgeNote(){ if(!ws||ws.readyState!==1){ setBridge('Connect first'); return; } google.script.run.withSuccessHandler((envelopesJson)=>{ ws.send(envelopesJson); }).getTestEnvelopes(); }
+
+document.getElementById('btnKick').onclick=()=>playKick();
+document.getElementById('btnHat').onclick=()=>playHat();
+document.getElementById('btnMIDI').onclick=enableMIDI;
+document.getElementById('btnMIDITest').onclick=()=>{ if(!midiOut){ enableMIDI(); return; } sendMIDINoteOn(36,110,9); setTimeout(()=>sendMIDINoteOff(36,9),120); };
+document.getElementById('btnLoad').onclick=loadFromSheet;
+document.getElementById('btnSave').onclick=saveToSheet;
+document.getElementById('btnPlayDemo').onclick=playDemo;
+document.getElementById('btnTimeline').onclick=()=>google.script.run.insertTimeline();
+document.getElementById('btnGrid').onclick=()=>google.script.run.insertStepGrid16();
+document.getElementById('btnBridge').onclick=connectBridge;
+document.getElementById('btnBridgePing').onclick=pingBridge;
+document.getElementById('btnBridgeNote').onclick=testBridgeNote;
+
+loadFromSheet();
+</script></body></html>

--- a/docs/PR_CELLBARS_PUSH_WS.md
+++ b/docs/PR_CELLBARS_PUSH_WS.md
@@ -1,0 +1,35 @@
+# PR: DAWSheet — CellBars Test Path (Add-on + Bridge Push)
+
+Summary
+
+Adds distrib/cellbars_tester_kit/ with a ready-to-share Google Sheets add-on (Welcome, Web MIDI) using a placeholder logo.
+
+Adds bridge/ Java WebSocket server stub that plays NOTE.PLAY on the default Java synth.
+
+Adds sidebar Bridge section: connect/ping/send test envelope to ws://127.0.0.1:17653.
+
+Why
+
+Faster "sheet → sound" for non-technical testers.
+
+Establishes the push path (no Sheets polling) we plan to standardize.
+
+Test plan
+
+Open a new Sheet → import apps/addon/ files into Apps Script.
+
+Run the bridge: cd bridge && ./gradlew run.
+
+In the sidebar: Play Kick (Web Audio), then Enable MIDI (optional).
+
+Click Bridge → Connect and Bridge Test NOTE.PLAY → hear synth beep.
+
+(Optional) Enable IAC + Logic and use Web MIDI instead.
+
+Follow-ups (separate PRs)
+
+Bridge MIDI port selection + latency meter.
+
+Envelope handlers: CC.SET, PROGRAM.CHANGE, CHORD.PLAY, etc.
+
+Arrangement compiler (Timeline → envelopes) and SMF export.


### PR DESCRIPTION
# PR: DAWSheet — CellBars Test Path (Add-on + Bridge Push)

Summary

Adds distrib/cellbars_tester_kit/ with a ready-to-share Google Sheets add-on (Welcome, Web MIDI) using a placeholder logo.

Adds bridge/ Java WebSocket server stub that plays NOTE.PLAY on the default Java synth.

Adds sidebar Bridge section: connect/ping/send test envelope to ws://127.0.0.1:17653.

Why

Faster "sheet → sound" for non-technical testers.

Establishes the push path (no Sheets polling) we plan to standardize.

Test plan

Open a new Sheet → import apps/addon/ files into Apps Script.

Run the bridge: cd bridge && ./gradlew run.

In the sidebar: Play Kick (Web Audio), then Enable MIDI (optional).

Click Bridge → Connect and Bridge Test NOTE.PLAY → hear synth beep.

(Optional) Enable IAC + Logic and use Web MIDI instead.

Follow-ups (separate PRs)

Bridge MIDI port selection + latency meter.

Envelope handlers: CC.SET, PROGRAM.CHANGE, CHORD.PLAY, etc.

Arrangement compiler (Timeline → envelopes) and SMF export.
